### PR TITLE
Update to work with Python 3.7

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-Django==1.10.1
-djangorestframework==3.4.7
-pytest==3.0.6
-pytest-django==3.1.2
+Django==1.11.22
+djangorestframework==3.9.4
+pytest==5.0.0
+pytest-django==3.5.1


### PR DESCRIPTION
I found with the pinned versions, I'd get a StopIteration exception when running the tests under Python 3.7.  Updated the requirements, and now all tests are green.